### PR TITLE
Fix symbol table

### DIFF
--- a/docs/SymbolTable.md
+++ b/docs/SymbolTable.md
@@ -1,7 +1,7 @@
 
 ```c
 typedef struct SymbolEntry {
-    SymbolType t; 
+    SymbolType t;
     u32 idx;
 } SymbolEntry;
 ```
@@ -13,7 +13,7 @@ expected to point to an external buffer.
 typedef struct SymbolMap {
     Allocator mem;
 
-    u32* keys;
+    StrID* keys;
     SymbolEntry* entries;
     u32 size;
     u32 cap;

--- a/include/libparasheet/lib_internal.h
+++ b/include/libparasheet/lib_internal.h
@@ -55,7 +55,7 @@ SString StringDel(StringTable* table, StrID index);
 const SString StringGet(StringTable* table, StrID index);
 
 #define StringCmp(a, b) \
-    (a == b)
+    (a.idx == b.idx) && (a.gen == b.gen)
 
 void StringFree(StringTable* table);
 
@@ -231,7 +231,7 @@ typedef enum SymbolType : u32 {
 } SymbolType;
 
 typedef struct SymbolEntry {
-    SymbolType type; 
+    SymbolType type;
     u32 idx;
 } SymbolEntry;
 
@@ -239,7 +239,7 @@ typedef struct SymbolEntry {
 typedef struct SymbolMap {
     Allocator mem;
 
-    u32* keys;
+    StrID* keys;
     SymbolEntry* entries;
     u32 size;
     u32 cap;

--- a/src/libparasheet/symbol.c
+++ b/src/libparasheet/symbol.c
@@ -1,129 +1,131 @@
-#include <stdint.h>
-#include <util/util.h>
 #include <libparasheet/lib_internal.h>
+#include <stdint.h>
 #include <string.h>
+#include <util/util.h>
 
-//Forward declaration for Indirect Recursion
+// Forward declaration for Indirect Recursion
 static u32 MapInsertInternal(SymbolMap* map, StrID key, SymbolEntry e);
 
-//Resize the symbol hash table
+// Resize the symbol hash table
 static void SymbolMapResize(SymbolMap* map) {
-    u32 oldsize = map->cap; 
+	u32 oldsize = map->cap;
 
-    while (map->size + 1 >= map->cap * MAX_LOAD_FACTOR) {
-        map->cap = map->cap ? map->cap * 2 : 2; 
-    }
+	while (map->size + 1 >= map->cap * MAX_LOAD_FACTOR) {
+		map->cap = map->cap ? map->cap * 2 : 2;
+	}
 
-    u32* okeys = map->keys; 
-    SymbolEntry* oentries = map->entries;
+	StrID* okeys = map->keys;
+	SymbolEntry* oentries = map->entries;
 
-    map->keys = Alloc(map->mem, map->cap * sizeof(u32));
-    map->entries = Alloc(map->mem, map->cap * sizeof(SymbolEntry));
+	map->keys = Alloc(map->mem, map->cap * sizeof(u32));
+	map->entries = Alloc(map->mem, map->cap * sizeof(SymbolEntry));
 
-    memset(map->keys, -1, map->cap * sizeof(u32));
-    memset(map->entries, 0, map->cap * sizeof(SymbolEntry)); //Technically not necessary but whatever
+	memset(map->keys, -1, map->cap * sizeof(u32));
+	memset(map->entries, 0,
+		   map->cap *
+			   sizeof(SymbolEntry)); // Technically not necessary but whatever
 
-    map->size = 0;
+	map->size = 0;
 
-    for (u32 i = 0; i < oldsize; i++) {
-        if (okeys[i] != UINT32_MAX) {
-            MapInsertInternal(map, okeys[i], oentries[i]);
-        }
-    }
+	for (u32 i = 0; i < oldsize; i++) {
+		if (okeys[i].idx != UINT32_MAX || okeys[i].gen != UINT32_MAX) {
+			MapInsertInternal(map, okeys[i], oentries[i]);
+		}
+	}
 
-
-    Free(map->mem, okeys, oldsize * sizeof(u32));
-    Free(map->mem, oentries, oldsize * sizeof(SymbolEntry));
+	Free(map->mem, okeys, oldsize * sizeof(u32));
+	Free(map->mem, oentries, oldsize * sizeof(SymbolEntry));
 }
 
-//Insertion which supports writing entries directly. Used in both
-//the public SymbolInsert and the internal Resize
+// Insertion which supports writing entries directly. Used in both
+// the public SymbolInsert and the internal Resize
 static u32 MapInsertInternal(SymbolMap* map, StrID key, SymbolEntry entry) {
-    if (map->size + 1 >= map->cap * MAX_LOAD_FACTOR)
-        SymbolMapResize(map);
+	if (map->size + 1 >= map->cap * MAX_LOAD_FACTOR)
+		SymbolMapResize(map);
 
-    u32 idx = hash((u8*)&key, sizeof(u32)) % map->cap;
+	u32 idx = hash((u8*)&key, sizeof(u32)) % map->cap;
 
-    for (u32 i = 0; i < map->cap; i++) {
-        u32 curr = map->keys[idx]; 
+	for (u32 i = 0; i < map->cap; i++) {
+		StrID curr = map->keys[idx];
 
-        if (StringCmp(key, curr)) {
-            return idx;
-        }
+		if (StringCmp(key, curr)) {
+			return idx;
+		}
 
-        if (curr == UINT32_MAX) {
-            map->size++;
-            map->keys[idx] = key;
-            map->entries[idx] = entry;
-            return idx;
-        }
+		if (curr.idx == UINT32_MAX && curr.gen == UINT32_MAX) {
+			map->size++;
+			map->keys[idx] = key;
+			map->entries[idx] = entry;
+			return idx;
+		}
 
-        idx = (idx + 1) % map->cap;
-    }
+		idx = (idx + 1) % map->cap;
+	}
 
-
-    panic();
+	panic();
 }
 
 u32 SymbolMapInsert(SymbolMap* map, StrID key) {
-    return MapInsertInternal(map, key, (SymbolEntry){});
+	return MapInsertInternal(map, key, (SymbolEntry){});
 }
 
 u32 SymbolMapGet(SymbolMap* map, StrID key) {
-    if (!map->cap) return -1;
+	if (!map->cap)
+		return -1;
 
-    u32 idx = hash((u8*)&key, sizeof(u32)) % map->cap;
+	u32 idx = hash((u8*)&key, sizeof(u32)) % map->cap;
 
-    for (u32 i = 0; i < map->cap; i++) {
-        u32 curr = map->keys[idx]; 
+	for (u32 i = 0; i < map->cap; i++) {
+		StrID curr = map->keys[idx];
 
-        if (StringCmp(key, curr)) {
-            return idx;
-        }
+		if (StringCmp(key, curr)) {
+			return idx;
+		}
 
-        if (curr == UINT32_MAX) {
-            return -1;
-        }
+		if (curr.idx == UINT32_MAX && curr.gen == UINT32_MAX) {
+			return -1;
+		}
 
-        idx = (idx + 1) % map->cap;
-    }
-    return -1;
+		idx = (idx + 1) % map->cap;
+	}
+	return -1;
 }
 
 void SymbolMapFree(SymbolMap* map) {
-    Free(map->mem, map->keys, map->cap * sizeof(u32));
-    Free(map->mem, map->entries, map->cap * sizeof(SymbolEntry));
+	Free(map->mem, map->keys, map->cap * sizeof(u32));
+	Free(map->mem, map->entries, map->cap * sizeof(SymbolEntry));
 }
 
 void SymbolInsert(SymbolTable* table, StrID key, SymbolEntry entry) {
-    u32 idx = SymbolMapInsert(&table->scopes[table->size - 1], key);
-    table->scopes[table->size - 1].entries[idx] = entry;
+	u32 idx = SymbolMapInsert(&table->scopes[table->size - 1], key);
+	table->scopes[table->size - 1].entries[idx] = entry;
 }
 
 SymbolEntry SymbolGet(SymbolTable* table, StrID key) {
-    for (i32 i = table->size - 1; i >= 0; i--) {
-        u32 e = SymbolMapGet(&table->scopes[i], key);
-        if (e != UINT32_MAX) return table->scopes[i].entries[e];
-    }
+	for (i32 i = table->size - 1; i >= 0; i--) {
+		u32 e = SymbolMapGet(&table->scopes[i], key);
+		if (e != UINT32_MAX)
+			return table->scopes[i].entries[e];
+	}
 
-    return (SymbolEntry){0};
+	return (SymbolEntry){0};
 }
 
 void SymbolPushScope(SymbolTable* table) {
-    if (table->size + 1 > table->cap) {
-        u32 oldsize = table->cap;
-        table->cap = table->cap ? table->cap * 2 : 2;
+	if (table->size + 1 > table->cap) {
+		u32 oldsize = table->cap;
+		table->cap = table->cap ? table->cap * 2 : 2;
 
-        table->scopes = Realloc(table->mem, table->scopes,
-                                oldsize * sizeof(SymbolMap),
-                                table->cap * sizeof(SymbolMap));
-    }
+		table->scopes =
+			Realloc(table->mem, table->scopes, oldsize * sizeof(SymbolMap),
+					table->cap * sizeof(SymbolMap));
+	}
 
-    table->scopes[table->size++] = (SymbolMap) {
-        .mem = table->mem,
-    };
+	table->scopes[table->size++] = (SymbolMap){
+		.mem = table->mem,
+	};
 }
 
 void SymbolPopScope(SymbolTable* table) {
-    SymbolMapFree(&table->scopes[--table->size]);
+	SymbolMapFree(&table->scopes[--table->size]);
 }

--- a/tests/libparasheet/symbol_table.c
+++ b/tests/libparasheet/symbol_table.c
@@ -3,67 +3,70 @@
 
 int main() {
 
-    SymbolMap map = {
-        .mem = GlobalAllocatorCreate(),
-    };
+	SymbolMap map = {
+		.mem = GlobalAllocatorCreate(),
+	};
 
-    for (u32 i = 0; i < 10; i++) {
-        u32 e = SymbolMapInsert(&map, i);
-        map.entries[e] = (SymbolEntry){
-            .type = 0,
-            .idx = i,
-        };
-    }
+	for (u32 i = 0; i < 10; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		u32 e = SymbolMapInsert(&map, insert);
+		map.entries[e] = (SymbolEntry){
+			.type = 0,
+			.idx = i,
+		};
+	}
 
-    for (u32 i = 0; i < 10; i++) {
-        u32 e = SymbolMapInsert(&map, i);
-        map.entries[e] = (SymbolEntry){
-            .type = 0,
-            .idx = i * 2,
-        };
-    }
+	for (u32 i = 0; i < 10; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		u32 e = SymbolMapInsert(&map, insert);
+		map.entries[e] = (SymbolEntry){
+			.type = 0,
+			.idx = i * 2,
+		};
+	}
 
-    print(stdout, "Table:\n");
-    for (u32 i = 0; i < map.cap; i++) {
-        print(stdout, "\t(%d %d)\n", map.keys[i], map.entries[i].idx);
-    }
+	print(stdout, "Table:\n");
+	for (u32 i = 0; i < map.cap; i++) {
+		print(stdout, "\t(%d %d)\n", map.keys[i], map.entries[i].idx);
+	}
 
-    print(stdout, "Vals:\n");
-    for (u32 i = 0; i < 10; i++) {
-        u32 e = SymbolMapGet(&map, i);
-        print(stdout, "\t(%d %d)\n", i, map.entries[e].idx);
-    }
+	print(stdout, "Vals:\n");
+	for (u32 i = 0; i < 10; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		u32 e = SymbolMapGet(&map, insert);
+		print(stdout, "\t(%d %d)\n", i, map.entries[e].idx);
+	}
 
-    SymbolMapFree(&map);
+	SymbolMapFree(&map);
 
+	SymbolTable t = {
+		.mem = GlobalAllocatorCreate(),
+	};
+	SymbolPushScope(&t);
 
-    SymbolTable t = {
-        .mem = GlobalAllocatorCreate(),
-    };
-    SymbolPushScope(&t);
+	for (u32 i = 0; i < 10; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		SymbolInsert(&t, insert, (SymbolEntry){.type = S_VAR, .idx = i});
+	}
+	SymbolPushScope(&t);
+	for (u32 i = 5; i < 15; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		SymbolInsert(&t, insert, (SymbolEntry){.type = S_VAR, .idx = i * 2});
+	}
 
-    for (u32 i = 0; i < 10; i++) {
-        SymbolInsert(&t, i, (SymbolEntry){.type = S_VAR, .idx = i});
-    }
-    SymbolPushScope(&t);
-    for (u32 i = 5; i < 15; i++) {
-        SymbolInsert(&t, i, (SymbolEntry){.type = S_VAR, .idx = i * 2});
-    }
+	for (u32 i = 0; i < 15; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		SymbolEntry e = SymbolGet(&t, insert);
+		print(stdout, "\t(%d %d %d)\n", i, e.type, e.idx);
+	}
 
-    for (u32 i = 0; i < 15; i++) {
-        SymbolEntry e = SymbolGet(&t, i);
-        print(stdout, "\t(%d %d %d)\n", i, e.type, e.idx);
-    }
+	SymbolPopScope(&t);
 
-    SymbolPopScope(&t);
+	for (u32 i = 0; i < 15; i++) {
+		StrID insert = {.idx = i, .gen = 1};
+		SymbolEntry e = SymbolGet(&t, insert);
+		print(stdout, "\t(%d %d %d)\n", i, e.type, e.idx);
+	}
 
-    for (u32 i = 0; i < 15; i++) {
-        SymbolEntry e = SymbolGet(&t, i);
-        print(stdout, "\t(%d %d %d)\n", i, e.type, e.idx);
-    }
-
-
-
-
-    return 0;
+	return 0;
 }


### PR DESCRIPTION
#50 broke the symbol table, as the symbol table expects every string to be a `u32`, and #50 made strings into structs. I've shuffled things around just enough to get things to compile, but I'm fairly certain that the symbol table is still broken here, and it needs more work to fix.

I might look at this tomorrow to see if I can figure out how to make it work when I'm a little more rested.